### PR TITLE
fix exception when gunzip errors

### DIFF
--- a/lib/webserver/WebServer.js
+++ b/lib/webserver/WebServer.js
@@ -103,10 +103,10 @@ const WebServer = function (options) {
             req.on('end', function() {
                 const uploadedGzippedMapData = Buffer.concat(data);
                 zlib.gunzip(uploadedGzippedMapData, (err, data) => {
-                    const dataToHash = data.length > 48 ? data.slice(20, data.length - 29) : data; //strip index,sequence + digest
-                    const hashOfNewMap = crypto.createHash('sha1').update(dataToHash).digest('base64');
-                    if(hashOfNewMap !== self.map.hash) {
-                        if (!err) {
+                    if (!err) {
+                        const dataToHash = data.length > 48 ? data.slice(20, data.length - 29) : data; //strip index,sequence + digest
+                        const hashOfNewMap = crypto.createHash('sha1').update(dataToHash).digest('base64');
+                        if(hashOfNewMap !== self.map.hash) {
                             const parsedHeader = RRMapParser.PARSE(data);
                             self.mapUploadInProgress = false;
                             if (parsedHeader.version && parsedHeader.version.major > 0) {


### PR DESCRIPTION
Check for an error of the gunzip before you want to do anything with the data.
When wrong data is send to this url valeduto throws an exception.